### PR TITLE
Support Hyundai Ioniq

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -99,6 +99,18 @@ function launch {
     fi
   fi
 
+  # One-time fix for a subset of OP3T with gyro orientation offsets.
+  # Remove and regenerate qcom sensor registry. Only done on OP3T mainboards.
+  # Performed exactly once. The old registry is preserved just-in-case, and
+  # doubles as a flag denoting we've already done the reset.
+  # TODO: we should really grow per-platform detect and setup routines
+  if ! $(grep -q "letv" /proc/cmdline) && [ ! -f "/persist/comma/op3t-sns-reg-backup" ]; then
+    echo "Performing OP3T sensor registry reset"
+    mv /persist/sensors/sns.reg /persist/comma/op3t-sns-reg-backup &&
+      rm -f /persist/sensors/sensors_settings /persist/sensors/error_log /persist/sensors/gyro_sensitity_cal &&
+      echo "restart" > /sys/kernel/debug/msm_subsys/slpi &&
+      sleep 5  # Give Android sensor subsystem a moment to recover
+  fi
 
   # handle pythonpath
   ln -sfn $(pwd) /data/pythonpath

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -273,7 +273,7 @@ def thermald_thread():
     # If device is offroad we want to cool down before going onroad
     # since going onroad increases load and can make temps go over 107
     # We only do this if there is a relay that prevents the car from faulting
-    if max_cpu_temp > 107. or bat_temp >= 63. or (has_relay and (started_ts is None) and max_cpu_temp > 75.0):
+    if max_cpu_temp > 107. or bat_temp >= 63. or (has_relay and (started_ts is None) and max_cpu_temp > 70.0):
       # onroad not allowed
       thermal_status = ThermalStatus.danger
     elif max_comp_temp > 96.0 or bat_temp > 60.:


### PR DESCRIPTION
Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for < Hyundai - IONIQ HYBRID- 2018 - Trim> CAR.IONIQ_EV_LTD: [{
68: 8, 127: 8, 304: 8, 320: 8, 339: 8, 352: 8, 356: 4, 544: 8, 576:8, 593: 8, 688: 5, 832: 8, 881: 8, 882: 8, 897: 8, 902: 8, 903: 8, 916: 8, 1040: 8, 1056: 8, 1057: 8, 1078: 4, 1136: 6, 1173: 8, 1225: 8, 1265: 4, 1280: 1, 1287: 4, 1290: 8, 1291: 8, 1292: 8, 1294: 8, 1322: 8, 1342: 6, 1345: 8, 1348: 8, 1355: 8, 1363: 8, 1369: 8, 1407: 8, 1427: 6, 1429: 8, 1430: 8, 1448: 8, 1456: 4, 1470: 8, 1476: 8, 1535: 8
}],
# Car support
This pull requests adds support for <Hyundai - IONIQ HYBRID- 2018 - Trim>.

https://my.comma.ai/cabana/?route=5399c75340359d11%7C2020-07-03--09-53-43&exp=1625506238&sig=lSNHGBwGoOmx5CpbHOV40bqSwqDlHI1r9zx3ZICD7HM%3D&max=16&url=https%3A%2F%2Fchffrprivate-vzn.azureedge.net%2Fchffrprivate3%2Fv2%2F5399c75340359d11%2F2c87a60ab8a806222322713fbf7e665f_2020-07-03--09-53-43



## Testing
Eon+black panda and it work very well 
